### PR TITLE
Don't use sudo

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,12 +48,12 @@ function installPods() {
 }
 
 function installCocoaPods() {
-  console.log("installing socoapods.");
+  console.log("installing cocoapods.");
 
   return new Promise((resolve, reject) => {
-    run("sudo gem install cocoapods")
+    run("gem install cocoapods")
       .then(() => {
-        console.log("sudo gem install cocoapods sucessfull");
+        console.log("gem install cocoapods sucessfull");
         resolve();
       })
       .catch(e => {


### PR DESCRIPTION
There's no reason to use sudo here, it's really fishy if a node module tries to get superuser permissions. Needing sudo for gem install likely means the install is polluting the global gem space. If you're using something like rvm to manage ruby installations, you don't need the sudo here.